### PR TITLE
(maint) Update network_interface type enable

### DIFF
--- a/lib/puppet/type/network_interface.rb
+++ b/lib/puppet/type/network_interface.rb
@@ -71,7 +71,7 @@ else
       enable:      {
         type:    'Optional[Boolean]',
         desc:    'Whether this network interface should be enabled on the target system.',
-        default: 'false'
+        default: false
       },
       name:     {
         type:   'String',


### PR DESCRIPTION
Enable field uses an optional boolean, change default value from string to a boolean.